### PR TITLE
Improve downloader request handling

### DIFF
--- a/src/zensvi/download/ams.py
+++ b/src/zensvi/download/ams.py
@@ -136,22 +136,16 @@ class AMSDownloader(BaseDownloader):
         """Get raw panorama IDs from the Amsterdam Street View API."""
         url = f"https://api.data.amsterdam.nl/panorama/panoramas/?near={lon},{lat}&radius={buffer}&srid=4326"
 
-        for attempt in range(10):
-            try:
-                proxy = random.choice(self._proxies)
-                user_agent = random.choice(self._user_agents)
-                headers = {"User-Agent": user_agent["user_agent"]}  # Extract the string from the dictionary
-                response = requests.get(url, proxies=proxy, headers=headers)
-                response.raise_for_status()
-                data = json.loads(response.content)
-                panoramas = data["_embedded"]["panoramas"]
-                return [item["pano_id"] for item in panoramas]
-            except Exception as e:
-                if attempt == 9:  # Last attempt
-                    warnings.warn(f"Failed to get panorama IDs after 5 attempts: {e}")
-                    return []
-                print(f"Attempt {attempt + 1} failed: {e}")
-                continue
+        headers = {"User-Agent": random.choice(self._user_agents)["user_agent"]}
+
+        try:
+            response = self._request_get(url, headers=headers, max_attempts=10, check_status=True)
+            data = response.json()
+            panoramas = data["_embedded"]["panoramas"]
+            return [item["pano_id"] for item in panoramas]
+        except (requests.exceptions.RequestException, json.JSONDecodeError) as exc:
+            warnings.warn(f"Failed to get panorama IDs after multiple attempts: {exc}")
+            return []
 
     def _filter_pids_date(self, pid_df, start_date, end_date):
         """Filter panorama IDs by date."""
@@ -161,23 +155,24 @@ class AMSDownloader(BaseDownloader):
     def _save_image(self, pid, data, cropped):
         """Save an image to disk."""
         img_path = os.path.join(self.dir_output, f"{pid}.jpg")
+        headers = {"User-Agent": random.choice(self._user_agents)["user_agent"]}
+
         try:
-            proxy = random.choice(self._proxies)
-            headers = {"User-Agent": random.choice(self._user_agents)["user_agent"]}
-            image = Image.open(
-                BytesIO(
-                    requests.get(
-                        data["_links"]["equirectangular_medium"]["href"],
-                        proxies=proxy,
-                        headers=headers,
-                    ).content
-                )
+            response = self._request_get(
+                data["_links"]["equirectangular_medium"]["href"],
+                headers=headers,
+                max_attempts=5,
+                timeout=30,
+                check_status=True,
             )
+            image = Image.open(BytesIO(response.content))
             if cropped:
                 image = image.crop((0, 0, image.width, image.height // 2))
             image.save(img_path)
-        except Exception:
-            self.logger.log_failed_pid(pid)
+        except (requests.exceptions.RequestException, Image.UnidentifiedImageError, OSError) as exc:
+            if self.logger is not None:
+                self.logger.log_failed_pid(pid)
+            print(f"Failed to save image for PID {pid}: {exc}")
 
     def download_svi(
         self,
@@ -300,35 +295,31 @@ class AMSDownloader(BaseDownloader):
 
         def process_pid(pid, max_retries=5):
             img_url = f"https://api.data.amsterdam.nl/panorama/panoramas/{pid}/"
+            headers = {"User-Agent": random.choice(self._user_agents)["user_agent"]}
 
-            for attempt in range(max_retries):
-                try:
-                    proxy = random.choice(self._proxies)
-                    headers = {"User-Agent": random.choice(self._user_agents)["user_agent"]}
-                    response = requests.get(img_url, proxies=proxy, headers=headers)
-                    data = json.loads(response.content)
+            try:
+                response = self._request_get(img_url, headers=headers, max_attempts=max_retries, check_status=True)
+                data = response.json()
 
-                    if response.status_code == 200:
-                        if not metadata_only:
-                            self._save_image(pid, data, cropped)
+                if not metadata_only:
+                    self._save_image(pid, data, cropped)
 
-                        return {
-                            "geometry": Point(data["geometry"]["coordinates"][:2]),
-                            "lat": data["geometry"]["coordinates"][1],
-                            "lon": data["geometry"]["coordinates"][0],
-                            "pano_id": data["pano_id"],
-                            "timestamp": data["timestamp"],
-                            "mission_year": data["mission_year"],
-                            "roll": data["roll"],
-                            "pitch": data["pitch"],
-                            "heading": data["heading"],
-                        }
-                except Exception as e:
-                    if attempt == max_retries - 1:  # Last attempt
-                        print(f"Failed to download data for PID {pid} after {max_retries} attempts: {str(e)}")
-                        return None
-                    continue
-            return None
+                return {
+                    "geometry": Point(data["geometry"]["coordinates"][:2]),
+                    "lat": data["geometry"]["coordinates"][1],
+                    "lon": data["geometry"]["coordinates"][0],
+                    "pano_id": data["pano_id"],
+                    "timestamp": data["timestamp"],
+                    "mission_year": data["mission_year"],
+                    "roll": data["roll"],
+                    "pitch": data["pitch"],
+                    "heading": data["heading"],
+                }
+            except (requests.exceptions.RequestException, json.JSONDecodeError) as exc:
+                print(f"Failed to download data for PID {pid} after {max_retries} attempts: {exc}")
+                if self.logger is not None and not metadata_only:
+                    self.logger.log_failed_pid(pid)
+                return None
 
         results = []
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:

--- a/src/zensvi/download/base.py
+++ b/src/zensvi/download/base.py
@@ -1,9 +1,11 @@
 import csv
 import os
+import random
 from abc import ABC, abstractmethod
 
 import pandas as pd
 import pkg_resources
+import requests
 
 
 class BaseDownloader(ABC):
@@ -80,6 +82,76 @@ class BaseDownloader(ABC):
                 ua = {"user_agent": line.strip()}
                 UA.append(ua)
         return UA
+
+    def _request_get(
+        self,
+        url,
+        *,
+        headers=None,
+        timeout=10,
+        allow_redirects=True,
+        max_attempts=5,
+        use_proxies=True,
+        check_status=False,
+    ):
+        """Perform a GET request with retries and optional proxy fallback.
+
+        This helper ensures that a direct connection is attempted before
+        falling back to configured proxies. It retries the request up to
+        ``max_attempts`` times and raises the last encountered exception if all
+        attempts fail.
+
+        Args:
+            url (str): The URL to request.
+            headers (dict, optional): Optional request headers. Defaults to
+                None.
+            timeout (int, optional): Timeout in seconds for the request.
+                Defaults to 10.
+            allow_redirects (bool, optional): Whether to allow redirects.
+                Defaults to True.
+            max_attempts (int, optional): Maximum number of attempts before
+                giving up. Defaults to 5.
+            use_proxies (bool, optional): Whether to use configured proxies
+                after the direct attempt. Defaults to True.
+            check_status (bool, optional): If True, call ``raise_for_status``
+                on the response before returning it. Defaults to False.
+
+        Returns:
+            requests.Response: The HTTP response object.
+
+        Raises:
+            requests.exceptions.RequestException: If all attempts fail.
+        """
+
+        attempts = 0
+        last_exception = None
+        proxy_pool = self._proxies if use_proxies and self._proxies else []
+
+        while attempts < max_attempts:
+            if attempts == 0 or not proxy_pool:
+                proxy = None
+            else:
+                proxy = random.choice(proxy_pool)
+
+            try:
+                response = requests.get(
+                    url,
+                    headers=headers,
+                    timeout=timeout,
+                    allow_redirects=allow_redirects,
+                    proxies=proxy,
+                )
+                if check_status:
+                    response.raise_for_status()
+                return response
+            except requests.exceptions.RequestException as exc:
+                last_exception = exc
+                attempts += 1
+                continue
+
+        if last_exception is not None:
+            raise last_exception
+        raise requests.exceptions.RequestException("Failed to fetch URL")
 
     def _log_write(self, pids):
         """Write panorama IDs to log file.

--- a/src/zensvi/download/kv.py
+++ b/src/zensvi/download/kv.py
@@ -214,36 +214,25 @@ class KVDownloader(BaseDownloader):
 
         def worker(row, output_dir, cropped, max_retries=5):
             url, panoid = row.url, row.id
-            user_agent = random.choice(self._user_agents)
-            proxy = random.choice(self._proxies)
+            headers = {"User-Agent": random.choice(self._user_agents)["user_agent"]}
 
             image_name = f"{panoid}.png"  # Use id for file name
             image_path = output_dir / image_name
 
-            for retry in range(max_retries):
-                try:
-                    response = requests.get(url, headers=user_agent, proxies=proxy, timeout=10)
-                    if response.status_code == 200:
-                        with open(image_path, "wb") as f:
-                            f.write(response.content)
+            try:
+                response = self._request_get(url, headers=headers, max_attempts=max_retries, timeout=10, check_status=True)
+                with open(image_path, "wb") as f:
+                    f.write(response.content)
 
-                        if cropped:
-                            img = Image.open(image_path)
-                            w, h = img.size
-                            img_cropped = img.crop((0, 0, w, h // 2))
-                            img_cropped.save(image_path)
-                        break
-                    else:
-                        if retry == max_retries - 1:  # Last retry
-                            if self.logger is not None:
-                                self.logger.log_failed_pid(panoid)
-                except Exception as e:
-                    if retry == max_retries - 1:  # Last retry
-                        if self.logger is not None:
-                            self.logger.log_failed_pid(panoid)
-                        print(f"Error: {e}")
-                    else:
-                        print(f"Retry {retry + 1}/{max_retries} failed: {e}")
+                if cropped:
+                    img = Image.open(image_path)
+                    w, h = img.size
+                    img_cropped = img.crop((0, 0, w, h // 2))
+                    img_cropped.save(image_path)
+            except (requests.exceptions.RequestException, Image.UnidentifiedImageError, OSError) as e:
+                if self.logger is not None:
+                    self.logger.log_failed_pid(panoid)
+                print(f"Error downloading panorama {panoid}: {e}")
 
         num_batches = (len(urls_df) + batch_size - 1) // batch_size
 

--- a/tests/test_downloader_base.py
+++ b/tests/test_downloader_base.py
@@ -1,0 +1,65 @@
+import random
+
+import pytest
+import requests
+
+from zensvi.download.base import BaseDownloader
+
+
+class DummyDownloader(BaseDownloader):
+    """Concrete implementation of ``BaseDownloader`` for testing."""
+
+    def _filter_pids_date(self, pid_df, start_date, end_date):  # pragma: no cover - not used in tests
+        return pid_df
+
+    def download_svi(self, *args, **kwargs):  # pragma: no cover - not used in tests
+        raise NotImplementedError
+
+
+class DummyResponse:
+    def __init__(self):
+        self.status_code = 200
+
+    def raise_for_status(self):
+        return None
+
+
+@pytest.fixture
+def downloader():
+    dl = DummyDownloader()
+    dl._proxies = [{"http": "proxy"}]  # Reduce proxy pool for deterministic tests
+    return dl
+
+
+def test_request_get_attempts_direct_first(monkeypatch, downloader):
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append(kwargs.get("proxies"))
+        return DummyResponse()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    response = downloader._request_get("http://example.com", max_attempts=3, check_status=True)
+
+    assert isinstance(response, DummyResponse)
+    assert calls == [None]
+
+
+def test_request_get_falls_back_to_proxy(monkeypatch, downloader):
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append(kwargs.get("proxies"))
+        if kwargs.get("proxies") is None:
+            raise requests.exceptions.Timeout("timeout")
+        return DummyResponse()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+
+    response = downloader._request_get("http://example.com", max_attempts=3, check_status=True)
+
+    assert isinstance(response, DummyResponse)
+    assert calls[0] is None
+    assert calls[1] == {"http": "proxy"}


### PR DESCRIPTION
## Summary
- add a reusable helper in `BaseDownloader` to retry HTTP GET requests and fall back to direct connections when proxies fail
- update the AMS and KartaView downloaders to rely on the new helper for fetching panorama metadata and imagery, with better error handling and logging
- add unit tests that exercise the new retry helper to ensure it prefers direct access and correctly falls back to proxies

## Testing
- `pytest tests/test_downloader_base.py` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68cb25213540832d954da3503f35c373